### PR TITLE
jupyter-server-mathjax 0.2.6 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: bb1e6b6dc0686c1fe386a22b5886163db548893a99c2810c36399e9c4ca23943
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true # [py<37 or s390x]
+  skip: true # [py<37]
 
 requirements:
   host:
@@ -31,16 +31,17 @@ test:
     - jupyter_server_mathjax
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - jupyter server extension list 2>&1 | grep -ie "jupyter_server_mathjax.*OK"
 
 about:
-  home: https://github.com/jupyter-server/jupyter_server_mathjax/
+  home: https://github.com/jupyter-server/jupyter_server_mathjax
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: MathJax resources as a Jupyter Server Extension.
-  dev_url: https://github.com/jupyter-server/jupyter_server_mathjax/
-  doc_url: https://github.com/jupyter-server/jupyter_server_mathjax/
+  dev_url: https://github.com/jupyter-server/jupyter_server_mathjax
+  doc_url: https://github.com/jupyter-server/jupyter_server_mathjax
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
     - tornado
     - jupyter_server
     - pytest-tornasync
-    - pytest_jupyter
+    - pytest-jupyter
   imports:
     - jupyter_server_mathjax
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
     - tornado
     - jupyter_server
     - pytest-tornasync
+    - pytest_jupyter
   imports:
     - jupyter_server_mathjax
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,21 +17,28 @@ build:
 requirements:
   host:
     - python
-    - jupyter-packaging >=0.10,<2
-    - nodejs 18.16.0
+    - setuptools
+    - wheel
     - pip
+    - jupyter-packaging >=0.10,<2
+    - jupyter_server >=1.1
   run:
     - python
-    - jupyter_server >=1.1,<3
 
 test:
   requires:
     - pip
+    - pytest
+    - traitlets
+    - tornado
+    - jupyter_server
+    - pytest-tornasync
   imports:
     - jupyter_server_mathjax
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest --pyargs jupyter_server_mathjax
     - jupyter server extension list 2>&1 | grep -ie "jupyter_server_mathjax.*OK"
 
 about:
@@ -39,9 +46,10 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: MathJax resources as a Jupyter Server Extension.
+  summary: MathJax resources endpoints for Jupyter Server.
+  description: MathJax resources endpoints for Jupyter Server.
   dev_url: https://github.com/jupyter-server/jupyter_server_mathjax
-  doc_url: https://github.com/jupyter-server/jupyter_server_mathjax
+  doc_url: https://github.com/jupyter-server/jupyter_server_mathjax/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,9 @@ requirements:
     - wheel
     - pip
     - jupyter-packaging >=0.10,<2
-    - jupyter_server >=1.1
   run:
     - python
+    - jupyter_server >=1.1
 
 test:
   requires:
@@ -31,7 +31,6 @@ test:
     - pytest
     - traitlets
     - tornado
-    - jupyter_server
     - pytest-tornasync
     - pytest-jupyter
   imports:


### PR DESCRIPTION
jupyter-server-mathjax 0.2.6 

**Destination channel:** Defaults

### Links

- [PKG-8660]
- dev_url:        https://github.com/jupyter-server/jupyter_server_mathjax/tree/0.2.6
- conda_forge:    https://github.com/conda-forge/jupyter-server-mathjax-feedstock
- pypi:           https://pypi.org/project/jupyter-server-mathjax/0.2.6
- pypi inspector: https://inspector.pypi.io/project/jupyter-server-mathjax/0.2.6/

### Explanation of changes:

- for some reason there is not pyt3.13 package for windows, rebuild to release


[PKG-8660]: https://anaconda.atlassian.net/browse/PKG-8660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ