### PR TITLE
jupyter-server-mathjax 0.2.6 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_check: false
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bb1e6b6dc0686c1fe386a22b5886163db548893a99c2810c36399e9c4ca23943
 
 build:
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true # [py<37]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
     - tornado
     - pytest-tornasync
     - pytest-jupyter
+    - msys2-grep  # [win]
   imports:
     - jupyter_server_mathjax
   commands:


### PR DESCRIPTION
jupyter-server-mathjax 0.2.6 

**Destination channel:** Defaults

### Links

- [PKG-12433]
- dev_url:        https://github.com/jupyter-server/jupyter_server_mathjax/tree/0.2.6
- conda_forge:    https://github.com/conda-forge/jupyter-server-mathjax-feedstock
- pypi:           https://pypi.org/project/jupyter-server-mathjax/0.2.6
- pypi inspector: https://inspector.pypi.io/project/jupyter-server-mathjax/0.2.6

### Explanation of changes:

- rebuild to release missing python3.14 package for windows


[PKG-12433]: https://anaconda.atlassian.net/browse/PKG-12433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ